### PR TITLE
style(css): add nowrap to right-aligned table cells

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -482,6 +482,9 @@ img[style="float: right;"], img[style="float:right;"], img[style="float: right"]
 :host table td:last-child, :host table th:last-child {
   padding-right: var(--table-padding-right-last-child, 0);
 }
+:host table td[align="right"]{
+  white-space: nowrap;
+}
 /* spacer-stylings */
 .spacer, .spacer-one, .spacer-two, .spacer-three, .spacer-four {
   display: block;


### PR DESCRIPTION
For recipe like in nature we want to have no wrap in the ingredients list.