### PR TITLE
refactor(Grid.js): replace eval() with template literals and other improvements

### DIFF
--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -79,20 +79,19 @@ export default class Grid extends Shadow() {
   }
 
   /**
-   * renders the html
+   * Renders the HTML.
    *
    * @return {Promise<void>}
    */
-  renderHTML () {
-    this.section = this.root.querySelector(this.cssSelector + ' > section') || document.createElement('section')
-    Array.from(this.root.children).forEach(node => {
-      if (node.tagName !== 'STYLE' && node.tagName !== 'SECTION') this.section.appendChild(node)
-    })
-    this.setAttribute('count-section-children', this.section.children.length)
-    Array.from(this.section.children).forEach(node => {
-      if ((node.getAttribute('style') || '').includes('background')) node.setAttribute('has-background', 'true')
-    })
-    this.html = [this.section]
-    return Promise.resolve()
+  async renderHTML() {
+    const section = this.root.querySelector(`${this.cssSelector} > section`) || document.createElement('section');
+    for (const node of Array.from(this.root.children)) {
+      if (node.tagName !== 'STYLE' && node.tagName !== 'SECTION') section.appendChild(node);
+    }
+    this.setAttribute('count-section-children', section.children.length);
+    for (const node of section.children) {
+      if ((node.getAttribute('style') || '').includes('background')) node.setAttribute('has-background', 'true');
+    }
+    this.html = [section];
   }
 }

--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -15,10 +15,10 @@ export default class Grid extends Shadow() {
   async connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldRenderCSS()) {
+    if (this.shouldComponentRenderCSS()) {
       showPromises.push(this.renderCSS())
     }
-    if (this.shouldRenderHTML()) {
+    if (this.shouldComponentRenderHTML()) {
       showPromises.push(this.renderHTML())
     }
     await Promise.all(showPromises)
@@ -30,7 +30,7 @@ export default class Grid extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldRenderCSS () {
+  shouldComponentRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -39,7 +39,7 @@ export default class Grid extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldRenderHTML () {
+  shouldComponentRenderHTML () {
     return !this.grid
   }
 

--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -39,42 +39,46 @@ export default class Grid extends Shadow() {
   }
 
   /**
-   * renders the o-grid css
+   * Renders the o-grid CSS.
    *
    * @return {Promise<void>}
    */
-  renderCSS () {
-    this.css = /* css */`
+  async renderCSS() {
+    this.css = /* css */ `
       :host > section {
-        display:grid;
-        ${this.hasAttribute('height')
-          ? `height: ${this.getAttribute('height') || '100%'};`
-          : ''
-        }
+        display: grid;
+        ${this.hasAttribute('height') ? `height: ${this.getAttribute('height') || '100%'};` : ''}
       }
-    `
+    `;
     /** @type {import("../../prototypes/Shadow.js").fetchCSSParams[]} */
     const styles = [
       {
         path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}../../../../css/reset.css`, // no variables for this reason no namespace
-        namespace: false
+        namespace: false,
       },
       {
         path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}../../../../css/style.css`, // apply namespace and fallback to allow overwriting on deeper level
-        namespaceFallback: true
-      }
-    ]
+        namespaceFallback: true,
+      },
+    ];
     switch (this.getAttribute('namespace')) {
       case 'grid-2colums2rows-':
-        return this.fetchCSS([{
-          path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}./2colums2rows-/2colums2rows-.css`, // apply namespace since it is specific and no fallback
-          namespace: false
-        }, ...styles], false).then(fetchCSSParams => {
-          // make template ${code} accessible
-          fetchCSSParams[0].styleNode.textContent = eval('`' + fetchCSSParams[0].style + '`')// eslint-disable-line no-eval
-        })
+        const fetchCSSParams = await this.fetchCSS(
+          [
+            {
+              path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}./2colums2rows-/2colums2rows-.css`, // apply namespace since it is specific and no fallback
+              namespace: false,
+            },
+            ...styles,
+          ],
+          false
+        );
+        // make template ${code} accessible
+        fetchCSSParams[0].styleNode.textContent = eval('`' + fetchCSSParams[0].style + '`')// eslint-disable-line no-eval
+        break;
       default:
-        return this.fetchCSS(styles, false)
+        await this.fetchCSS(styles, false);
+        break;
     }
   }
 

--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -12,30 +12,35 @@ import { Shadow } from '../../prototypes/Shadow.js'
  * @css {}
  */
 export default class Grid extends Shadow() {
-  connectedCallback () {
-    this.hidden = true
-    const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
-    Promise.all(showPromises).then(() => (this.hidden = false))
+  async connectedCallback() {
+    this.hidden = true;
+    const showPromises = [];
+    if (this.shouldRenderCSS()) {
+      showPromises.push(this.renderCSS());
+    }
+    if (this.shouldRenderHTML()) {
+      showPromises.push(this.renderHTML());
+    }
+    await Promise.all(showPromises);
+    this.hidden = false;
   }
 
   /**
-   * evaluates if a render is necessary
+   * Evaluates whether a render is necessary.
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
-    return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
+  shouldRenderCSS() {
+    return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`);
   }
 
   /**
-   * evaluates if a render is necessary
+   * Evaluates whether a render is necessary.
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
-    return !this.grid
+  shouldRenderHTML() {
+    return !this.grid;
   }
 
   /**

--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -49,37 +49,36 @@ export default class Grid extends Shadow() {
    * @return {Promise<void>}
    */
   async renderCSS() {
+    const url = import.meta.url.replace(/(.*\/)(.*)$/, '$1');
     this.css = /* css */ `
       :host > section {
         display: grid;
         ${this.hasAttribute('height') ? `height: ${this.getAttribute('height') || '100%'};` : ''}
       }
     `;
-    /** @type {import("../../prototypes/Shadow.js").fetchCSSParams[]} */
     const styles = [
       {
-        path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}../../../../css/reset.css`, // no variables for this reason no namespace
+        path: `${url}../../../../css/reset.css`,
         namespace: false,
       },
       {
-        path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}../../../../css/style.css`, // apply namespace and fallback to allow overwriting on deeper level
+        path: `${url}../../../../css/style.css`,
         namespaceFallback: true,
       },
     ];
     switch (this.getAttribute('namespace')) {
       case 'grid-2colums2rows-':
-        const fetchCSSParams = await this.fetchCSS(
+        const [{ styleNode, style }] = await this.fetchCSS(
           [
             {
-              path: `${import.meta.url.replace(/(.*\/)(.*)$/, '$1')}./2colums2rows-/2colums2rows-.css`, // apply namespace since it is specific and no fallback
+              path: `${url}./2colums2rows-/2colums2rows-.css`,
               namespace: false,
             },
             ...styles,
           ],
           false
         );
-        // make template ${code} accessible
-        fetchCSSParams[0].styleNode.textContent = eval('`' + fetchCSSParams[0].style + '`')// eslint-disable-line no-eval
+        styleNode.textContent = `${style}`;
         break;
       default:
         await this.fetchCSS(styles, false);

--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -12,17 +12,17 @@ import { Shadow } from '../../prototypes/Shadow.js'
  * @css {}
  */
 export default class Grid extends Shadow() {
-  async connectedCallback() {
-    this.hidden = true;
-    const showPromises = [];
+  async connectedCallback () {
+    this.hidden = true
+    const showPromises = []
     if (this.shouldRenderCSS()) {
-      showPromises.push(this.renderCSS());
+      showPromises.push(this.renderCSS())
     }
     if (this.shouldRenderHTML()) {
-      showPromises.push(this.renderHTML());
+      showPromises.push(this.renderHTML())
     }
-    await Promise.all(showPromises);
-    this.hidden = false;
+    await Promise.all(showPromises)
+    this.hidden = false
   }
 
   /**
@@ -30,8 +30,8 @@ export default class Grid extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldRenderCSS() {
-    return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`);
+  shouldRenderCSS () {
+    return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
   /**
@@ -39,8 +39,8 @@ export default class Grid extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldRenderHTML() {
-    return !this.grid;
+  shouldRenderHTML () {
+    return !this.grid
   }
 
   /**
@@ -48,41 +48,41 @@ export default class Grid extends Shadow() {
    *
    * @return {Promise<void>}
    */
-  async renderCSS() {
-    const url = import.meta.url.replace(/(.*\/)(.*)$/, '$1');
+  async renderCSS () {
+    const url = import.meta.url.replace(/(.*\/)(.*)$/, '$1')
     this.css = /* css */ `
       :host > section {
         display: grid;
         ${this.hasAttribute('height') ? `height: ${this.getAttribute('height') || '100%'};` : ''}
       }
-    `;
+    `
     const styles = [
       {
         path: `${url}../../../../css/reset.css`,
-        namespace: false,
+        namespace: false
       },
       {
         path: `${url}../../../../css/style.css`,
-        namespaceFallback: true,
-      },
-    ];
+        namespaceFallback: true
+      }
+    ]
     switch (this.getAttribute('namespace')) {
       case 'grid-2colums2rows-':
         const [{ styleNode, style }] = await this.fetchCSS(
           [
             {
               path: `${url}./2colums2rows-/2colums2rows-.css`,
-              namespace: false,
+              namespace: false
             },
-            ...styles,
+            ...styles
           ],
           false
-        );
-        styleNode.textContent = `${style}`;
-        break;
+        )
+        styleNode.textContent = `${style}`
+        break
       default:
-        await this.fetchCSS(styles, false);
-        break;
+        await this.fetchCSS(styles, false)
+        break
     }
   }
 
@@ -91,15 +91,15 @@ export default class Grid extends Shadow() {
    *
    * @return {Promise<void>}
    */
-  async renderHTML() {
-    const section = this.root.querySelector(`${this.cssSelector} > section`) || document.createElement('section');
+  async renderHTML () {
+    const section = this.root.querySelector(`${this.cssSelector} > section`) || document.createElement('section')
     for (const node of Array.from(this.root.children)) {
-      if (node.tagName !== 'STYLE' && node.tagName !== 'SECTION') section.appendChild(node);
+      if (node.tagName !== 'STYLE' && node.tagName !== 'SECTION') section.appendChild(node)
     }
-    this.setAttribute('count-section-children', section.children.length);
+    this.setAttribute('count-section-children', section.children.length)
     for (const node of section.children) {
-      if ((node.getAttribute('style') || '').includes('background')) node.setAttribute('has-background', 'true');
+      if ((node.getAttribute('style') || '').includes('background')) node.setAttribute('has-background', 'true')
     }
-    this.html = [section];
+    this.html = [section]
   }
 }


### PR DESCRIPTION
- Introduce async/await to the functions that return promises
- Replace eval() with template literals and expressions inside ${}
- Tiny improvements to increase readability 