### PR TITLE
refactor(*.js): rename shouldComponentRenderCSS/HTML to shouldRenderCSS/HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ HTML/CSS Tooling:
 TODO Cleanup Sprints:
 - [ ] hover on parent prototype class which can be inherited (mouseover|mouseout)
 - [ ] keep body hidden at connected callback until style.css is loaded https://github.com/mits-gossau/web-components-toolbox/blob/master/src/es/components/organisms/body/Body.js
-- [ ] rename should "component" render
 - [ ] fetchCSS.then replace to replaces property
 - [ ] from loadChildComponents to shadow fetchModules
 - [ ] transform all import.meta.url.replace(/(.*\/)(.*)$/, '$1') to this.importMetaUrl

--- a/src/es/components/atoms/arrow/Arrow.js
+++ b/src/es/components/atoms/arrow/Arrow.js
@@ -37,8 +37,8 @@ export default class Arrow extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.mouseEventElement.addEventListener('mouseover', this.mouseoverListener)
     this.mouseEventElement.addEventListener('mouseout', this.mouseoutListener)
   }
@@ -68,7 +68,7 @@ export default class Arrow extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -77,7 +77,7 @@ export default class Arrow extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.svg
   }
 

--- a/src/es/components/atoms/breadcrumb/Breadcrumb.js
+++ b/src/es/components/atoms/breadcrumb/Breadcrumb.js
@@ -15,7 +15,7 @@ export default class Breadcrumb extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
   }
 
   /**
@@ -23,7 +23,7 @@ export default class Breadcrumb extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/atoms/button/Button.js
+++ b/src/es/components/atoms/button/Button.js
@@ -78,8 +78,8 @@ export default class Button extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.button.addEventListener('click', this.clickListener)
     if (this.getAttribute('answer-event-name')) document.body.addEventListener(this.getAttribute('answer-event-name'), this.answerEventListener)
     this.attributeChangedCallback('disabled')
@@ -117,7 +117,7 @@ export default class Button extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector('style[_css]')
   }
 
@@ -126,7 +126,7 @@ export default class Button extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.button || !this.label
   }
 

--- a/src/es/components/atoms/email/EMail.js
+++ b/src/es/components/atoms/email/EMail.js
@@ -30,7 +30,7 @@ export default class Email extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.addEventListener('click', this.clickListener)
   }
 
@@ -43,7 +43,7 @@ export default class Email extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.root.querySelector('a')
   }
 

--- a/src/es/components/atoms/emotionPictures/EmotionPictures.js
+++ b/src/es/components/atoms/emotionPictures/EmotionPictures.js
@@ -73,7 +73,7 @@ export default class EmotionPictures extends Intersection() {
     }
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
     if (this.aPicture && this.aPicture.hasAttribute('picture-load') && !this.aPicture.hasAttribute('loaded')) {
       showPromises.push(/** @type {Promise<void>} */(new Promise(resolve => this.addEventListener('picture-load', event => {
         if (!event || !event.detail || !event.detail.error) resolve()
@@ -97,7 +97,7 @@ export default class EmotionPictures extends Intersection() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/atoms/googleMaps/GoogleMaps.js
+++ b/src/es/components/atoms/googleMaps/GoogleMaps.js
@@ -30,8 +30,8 @@ export default class GoogleMaps extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     if (this.transportIcons) {
       this.transportIcons.forEach(transportIcon => {
         transportIcon.addEventListener('click', this.googleMapTransport)
@@ -50,7 +50,7 @@ export default class GoogleMaps extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -59,7 +59,7 @@ export default class GoogleMaps extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.scripts.length
   }
 

--- a/src/es/components/atoms/hotspot/Hotspot.js
+++ b/src/es/components/atoms/hotspot/Hotspot.js
@@ -41,8 +41,8 @@ export default class Hotspot extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.buttonOpen.addEventListener('click', this.buttonClickListener)
     this.buttonClose.addEventListener('click', this.buttonClickListener)
   }
@@ -57,7 +57,7 @@ export default class Hotspot extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -66,7 +66,7 @@ export default class Hotspot extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.hasRendered
   }
 

--- a/src/es/components/atoms/iconAmp/IconAmp.js
+++ b/src/es/components/atoms/iconAmp/IconAmp.js
@@ -25,8 +25,8 @@ export default class IconAmp extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.mouseEventElement.addEventListener('mouseover', this.mouseoverListener)
     this.mouseEventElement.addEventListener('mouseout', this.mouseoutListener)
   }
@@ -42,7 +42,7 @@ export default class IconAmp extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -51,7 +51,7 @@ export default class IconAmp extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.svg
   }
 

--- a/src/es/components/atoms/iconLocation/IconLocation.js
+++ b/src/es/components/atoms/iconLocation/IconLocation.js
@@ -25,8 +25,8 @@ export default class IconLocation extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.mouseEventElement.addEventListener('mouseover', this.mouseoverListener)
     this.mouseEventElement.addEventListener('mouseout', this.mouseoutListener)
   }
@@ -42,7 +42,7 @@ export default class IconLocation extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -51,7 +51,7 @@ export default class IconLocation extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.svg
   }
 

--- a/src/es/components/atoms/iconPaperclip/IconPaperclip.js
+++ b/src/es/components/atoms/iconPaperclip/IconPaperclip.js
@@ -25,8 +25,8 @@ export default class IconPaperclip extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.mouseEventElement.addEventListener('mouseover', this.mouseoverListener)
     this.mouseEventElement.addEventListener('mouseout', this.mouseoutListener)
   }
@@ -42,7 +42,7 @@ export default class IconPaperclip extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -51,7 +51,7 @@ export default class IconPaperclip extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.svg
   }
 

--- a/src/es/components/atoms/iframe/Iframe.js
+++ b/src/es/components/atoms/iframe/Iframe.js
@@ -26,9 +26,9 @@ export default class Iframe extends Intersection() {
 
   connectedCallback () {
     super.connectedCallback()
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
     if (!this.intersecting) {
-      this.intersecting = this.shouldComponentRenderHTML()
+      this.intersecting = this.shouldRenderHTML()
         ? this.renderHTML()
         : () =>
             console.warn(
@@ -53,7 +53,7 @@ export default class Iframe extends Intersection() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(
       `:host > style[_css], ${this.tagName} > style[_css]`
     )
@@ -64,7 +64,7 @@ export default class Iframe extends Intersection() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return this.template
   }
 

--- a/src/es/components/atoms/input/Input.js
+++ b/src/es/components/atoms/input/Input.js
@@ -79,8 +79,8 @@ export default class Input extends Shadow() {
 
   connectedCallback () {
     // render template
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
 
     // init configuration
     this.disabled = this.hasAttribute('disabled')
@@ -125,7 +125,7 @@ export default class Input extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector('style[_css]')
   }
 
@@ -134,7 +134,7 @@ export default class Input extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.inputField
   }
 

--- a/src/es/components/atoms/link/Link.js
+++ b/src/es/components/atoms/link/Link.js
@@ -50,8 +50,8 @@ export default class Link extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     if (this.mouseEventElement) {
       this.mouseEventElement.addEventListener('mouseover', this.mouseoverListener)
       this.mouseEventElement.addEventListener('mouseout', this.mouseoutListener)
@@ -72,7 +72,7 @@ export default class Link extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -81,7 +81,7 @@ export default class Link extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     if (!this._hasRendered) return (this._hasRendered = true)
     return false
   }

--- a/src/es/components/atoms/loading/Loading.js
+++ b/src/es/components/atoms/loading/Loading.js
@@ -12,8 +12,8 @@ import { Shadow } from '../../prototypes/Shadow.js'
  */
 export default class Loading extends Shadow() {
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
   }
 
   /**
@@ -21,7 +21,7 @@ export default class Loading extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -30,7 +30,7 @@ export default class Loading extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.root.querySelector(':host > div')
   }
 

--- a/src/es/components/atoms/logo/Logo.js
+++ b/src/es/components/atoms/logo/Logo.js
@@ -72,8 +72,8 @@ export default class Logo extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     self.addEventListener('resize', this.resizeListener)
   }
 
@@ -86,7 +86,7 @@ export default class Logo extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -95,7 +95,7 @@ export default class Logo extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.img && !!this.getAttribute('src')
   }
 

--- a/src/es/components/atoms/menuIcon/MenuIcon.js
+++ b/src/es/components/atoms/menuIcon/MenuIcon.js
@@ -38,8 +38,8 @@ export default class MenuIcon extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     if (!this.hasAttribute('no-click')) this.addEventListener('click', this.clickListener)
   }
 
@@ -52,7 +52,7 @@ export default class MenuIcon extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -61,7 +61,7 @@ export default class MenuIcon extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.root.querySelector('div')
   }
 

--- a/src/es/components/atoms/picture/Picture.js
+++ b/src/es/components/atoms/picture/Picture.js
@@ -67,8 +67,8 @@ export default class Picture extends Intersection() {
 
   connectedCallback () {
     super.connectedCallback()
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     if (this.hasAttribute('open-modal')) {
       this.setAttribute('aria-haspopup', 'true')
       this.addEventListener('click', this.clickListener)
@@ -119,7 +119,7 @@ export default class Picture extends Intersection() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -128,7 +128,7 @@ export default class Picture extends Intersection() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.picture
   }
 

--- a/src/es/components/atoms/sliderButton/SliderButton.js
+++ b/src/es/components/atoms/sliderButton/SliderButton.js
@@ -77,8 +77,8 @@ export default class SliderButton extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     document.body.addEventListener('carousel-two-seperate-nav-changed', this.carouselChanged)
     this.slider.addEventListener('mouseup', this.sliderChange)
     this.slider.addEventListener('touchend', this.sliderChange)
@@ -95,7 +95,7 @@ export default class SliderButton extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -104,7 +104,7 @@ export default class SliderButton extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.hasRendered
   }
 

--- a/src/es/components/atoms/totalPrice/TotalPrice.js
+++ b/src/es/components/atoms/totalPrice/TotalPrice.js
@@ -27,8 +27,8 @@ export default class TotalPrice extends Shadow() {
   }
 
   connectedCallback() {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     document.body.addEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
   }
 
@@ -58,7 +58,7 @@ export default class TotalPrice extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS() {
+  shouldRenderCSS() {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -68,7 +68,7 @@ export default class TotalPrice extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML() {
+  shouldRenderHTML() {
     return !this.totalPriceElement
   }
 

--- a/src/es/components/atoms/video/Video.js
+++ b/src/es/components/atoms/video/Video.js
@@ -46,8 +46,8 @@ export default class Video extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
   }
 
   /**
@@ -55,7 +55,7 @@ export default class Video extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -64,7 +64,7 @@ export default class Video extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.video
   }
 

--- a/src/es/components/contentful/news/News.js
+++ b/src/es/components/contentful/news/News.js
@@ -27,7 +27,7 @@ export default class News extends Shadow() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
     const renderedHTML = () => {
       this.backBtn.addEventListener('click', this.clickListener)
       sessionStorage.setItem('news-viewed', 'TRUE')
@@ -55,7 +55,7 @@ export default class News extends Shadow() {
     this.backBtn.removeEventListener('click', this.clickListener)
   }
 
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/contentful/newsList/NewsList.js
+++ b/src/es/components/contentful/newsList/NewsList.js
@@ -24,7 +24,7 @@ export default class NewsList extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
     document.body.addEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
     this.hidden = true
     Promise.all([this.loadScriptDependency(), this.loadDependency()]).then(() => this.dispatchEvent(new CustomEvent(this.getAttribute('request-event-name') || 'request-event-name', {
@@ -75,7 +75,7 @@ export default class NewsList extends Shadow() {
     })
   }
 
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/contentful/newsPreview/NewsPreview.js
+++ b/src/es/components/contentful/newsPreview/NewsPreview.js
@@ -10,15 +10,15 @@ export default class NewsPreview extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
   }
 
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.newsWrapper
   }
 
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/controllers/tagManager/TagManager.js
+++ b/src/es/components/controllers/tagManager/TagManager.js
@@ -27,9 +27,9 @@ export default class TagManager extends Shadow() {
     this.wcConfigLoadListener = event => {
       if (this.getAttribute('timeout') && this.getAttribute('timeout') !== null) {
         setTimeout(() => {
-          if (this.shouldComponentRenderHTML()) this.render()
+          if (this.shouldRenderHTML()) this.render()
         }, Number(this.getAttribute('timeout')))
-      } else if (this.shouldComponentRenderHTML()) this.render()
+      } else if (this.shouldRenderHTML()) this.render()
     }
   }
 
@@ -38,9 +38,9 @@ export default class TagManager extends Shadow() {
       document.body.addEventListener(this.getAttribute('wc-config-load') || 'wc-config-load', this.wcConfigLoadListener, { once: true })
     } else if (this.getAttribute('timeout') && this.getAttribute('timeout') !== null) {
       setTimeout(() => {
-        if (this.shouldComponentRenderHTML()) this.render()
+        if (this.shouldRenderHTML()) this.render()
       }, Number(this.getAttribute('timeout')))
-    } else if (this.shouldComponentRenderHTML()) this.render()
+    } else if (this.shouldRenderHTML()) this.render()
   }
 
   /**
@@ -48,7 +48,7 @@ export default class TagManager extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.scripts.length
   }
 

--- a/src/es/components/mcs/widget/Widget.js
+++ b/src/es/components/mcs/widget/Widget.js
@@ -54,7 +54,7 @@ export default class Widget extends Prototype() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRender()) showPromises.push(this.render())
+    if (this.shouldRender()) showPromises.push(this.render())
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -63,7 +63,7 @@ export default class Widget extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRender () {
+  shouldRender () {
     return !this.mscWrapper
   }
 

--- a/src/es/components/molecules/carousel/Carousel.js
+++ b/src/es/components/molecules/carousel/Carousel.js
@@ -134,8 +134,8 @@ export default class MacroCarousel extends Shadow() {
 
   connectedCallback () {
     const runResizePromises = []
-    if (this.shouldComponentRenderCSS()) runResizePromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) runResizePromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) runResizePromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) runResizePromises.push(this.renderHTML())
     this.hidden = true
     const showPromises = Array.from(runResizePromises)
     self.addEventListener('resize', this.resizeListener)
@@ -198,7 +198,7 @@ export default class MacroCarousel extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -207,7 +207,7 @@ export default class MacroCarousel extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.scripts.length
   }
 

--- a/src/es/components/molecules/carouselTwo/CarouselTwo.js
+++ b/src/es/components/molecules/carouselTwo/CarouselTwo.js
@@ -127,8 +127,8 @@ export default class CarouselTwo extends Shadow() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) showPromises.push(this.renderHTML())
     Array.from(this.section.children).concat(Array.from(this.nav.children)).forEach(node => {
       const picture = node.tagName === 'A-PICTURE'
         ? node
@@ -168,7 +168,7 @@ export default class CarouselTwo extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -177,7 +177,7 @@ export default class CarouselTwo extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.section || !this.nav || !this.arrowNav
   }
 

--- a/src/es/components/molecules/cookieBanner/CookieBanner.js
+++ b/src/es/components/molecules/cookieBanner/CookieBanner.js
@@ -66,8 +66,8 @@ export default class CookieBanner extends Shadow() {
 
   connectedCallback () {
     if (!this.shown) {
-      if (this.shouldComponentRenderCSS()) this.renderCSS()
-      if (this.shouldComponentRenderHTML()) this.renderHTML()
+      if (this.shouldRenderCSS()) this.renderCSS()
+      if (this.shouldRenderHTML()) this.renderHTML()
       this.addEventListener('click', this.clickListener)
       setTimeout(() => this.section.classList.add('show'), this.getAttribute('timeout') || 2000)
     } else {
@@ -88,7 +88,7 @@ export default class CookieBanner extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -97,7 +97,7 @@ export default class CookieBanner extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.section
   }
 

--- a/src/es/components/molecules/details/Details.js
+++ b/src/es/components/molecules/details/Details.js
@@ -132,8 +132,8 @@ export const Details = (ChosenHTMLElement = Mutation()) => class Details extends
     super.connectedCallback()
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) this.renderHTML()
     document.body.addEventListener(this.openEventName, this.openEventListener)
     self.addEventListener('resize', this.resizeListener)
     this.root.addEventListener('click', this.clickEventListener)
@@ -303,7 +303,7 @@ export const Details = (ChosenHTMLElement = Mutation()) => class Details extends
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -312,7 +312,7 @@ export const Details = (ChosenHTMLElement = Mutation()) => class Details extends
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.divSummary
   }
 

--- a/src/es/components/molecules/flockler/Flockler.js
+++ b/src/es/components/molecules/flockler/Flockler.js
@@ -38,8 +38,8 @@ export default class Flockler extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     self.addEventListener('message', this.messageListener)
     self.addEventListener('message', this.messageListenerAppear)
   }
@@ -53,7 +53,7 @@ export default class Flockler extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -62,7 +62,7 @@ export default class Flockler extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.iframe
   }
 

--- a/src/es/components/molecules/form/Form.js
+++ b/src/es/components/molecules/form/Form.js
@@ -63,8 +63,8 @@ export default class Form extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     if (this.submit) this.submit.addEventListener('click', this.clickListener)
     this.textarea.forEach(a => {
       if (a.hasAttribute('maxlength') && !a.hasAttribute('no-counter')) {
@@ -89,7 +89,7 @@ export default class Form extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -98,7 +98,7 @@ export default class Form extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.root.querySelector('span.counter')
   }
 

--- a/src/es/components/molecules/imageHotspot/ImageHotspot.js
+++ b/src/es/components/molecules/imageHotspot/ImageHotspot.js
@@ -20,8 +20,8 @@ export default class ImageHotspot extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
   }
 
   disconnectedCallback () {
@@ -33,7 +33,7 @@ export default class ImageHotspot extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -42,7 +42,7 @@ export default class ImageHotspot extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.hasRendered
   }
 

--- a/src/es/components/molecules/navigation/Navigation.js
+++ b/src/es/components/molecules/navigation/Navigation.js
@@ -112,8 +112,8 @@ export default class Navigation extends Mutation() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) showPromises.push(this.renderHTML())
     Promise.all(showPromises).then(() => {
       this.hidden = false
       this.checkIfWrapped(true)
@@ -174,7 +174,7 @@ export default class Navigation extends Mutation() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -183,7 +183,7 @@ export default class Navigation extends Mutation() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.nav
   }
 

--- a/src/es/components/molecules/pagination/Pagination.js
+++ b/src/es/components/molecules/pagination/Pagination.js
@@ -37,7 +37,7 @@ export default class Pagination extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
     self.addEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
     this.pagination.addEventListener('click', this.clickListener)
   }
@@ -58,7 +58,7 @@ export default class Pagination extends Shadow() {
     }))
   }
 
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/molecules/pictureText/PictureText.js
+++ b/src/es/components/molecules/pictureText/PictureText.js
@@ -33,8 +33,8 @@ export default class Hotspot extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     this.button.addEventListener('click', this.buttonClickListener)
     this.addEventListener('click', this.clickListener)
   }
@@ -49,7 +49,7 @@ export default class Hotspot extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -58,7 +58,7 @@ export default class Hotspot extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.wrapper
   }
 

--- a/src/es/components/molecules/pictureWithPicture/PictureWithPicture.js
+++ b/src/es/components/molecules/pictureWithPicture/PictureWithPicture.js
@@ -19,8 +19,8 @@ export default class PictureWithPicture extends Shadow() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) this.renderHTML()
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -29,7 +29,7 @@ export default class PictureWithPicture extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -38,7 +38,7 @@ export default class PictureWithPicture extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.wrapper
   }
 

--- a/src/es/components/molecules/recipeList/RecipeList.js
+++ b/src/es/components/molecules/recipeList/RecipeList.js
@@ -16,7 +16,7 @@ export default class RecipeList extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
     this.renderHTML('loading')
     document.body.addEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
     this.dispatchEvent(new CustomEvent(this.getAttribute('request-event-name') || 'request-event-name', {
@@ -30,7 +30,7 @@ export default class RecipeList extends Shadow() {
     document.body.removeEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
   }
 
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/molecules/tagFilter/TagFilter.js
+++ b/src/es/components/molecules/tagFilter/TagFilter.js
@@ -21,9 +21,9 @@ export default class TagFilter extends Mutation() {
 
   connectedCallback () {
     super.connectedCallback()
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
     // @ts-ignore
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderHTML()) this.renderHTML()
     if (this.getAttribute('answer-event-name')) document.body.addEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventListener)
   }
 
@@ -36,11 +36,11 @@ export default class TagFilter extends Mutation() {
     this.setAttribute('count-children', Array.from(this.root.children).filter(child => child.tagName !== 'STYLE').length)
   }
 
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.tagFilterWrapper
   }
 

--- a/src/es/components/molecules/teaser/Teaser.js
+++ b/src/es/components/molecules/teaser/Teaser.js
@@ -35,7 +35,7 @@ export default class Teaser extends Intersection() {
     super.connectedCallback()
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
     if (this.aPicture && this.aPicture.hasAttribute('picture-load') && !this.aPicture.hasAttribute('loaded')) showPromises.push(new Promise(resolve => this.addEventListener('picture-load', event => resolve(), { once: true })))
     Promise.all(showPromises).then(() => {
       if (!this.hasAttribute('no-figcaption-bg-color-equal')) {
@@ -75,7 +75,7 @@ export default class Teaser extends Intersection() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/msrc/cookieBanner/CookieBanner.js
+++ b/src/es/components/msrc/cookieBanner/CookieBanner.js
@@ -39,9 +39,9 @@ export default class CookieBanner extends Prototype() {
     this.transitionendListener = event => {
       if (this.getAttribute('timeout') && this.getAttribute('timeout') !== null) {
         setTimeout(() => {
-          if (this.shouldComponentRenderHTML()) this.render()
+          if (this.shouldRenderHTML()) this.render()
         }, Number(this.getAttribute('timeout')))
-      } else if (this.shouldComponentRenderHTML()) this.render()
+      } else if (this.shouldRenderHTML()) this.render()
     }
   }
 
@@ -50,9 +50,9 @@ export default class CookieBanner extends Prototype() {
       document.body.addEventListener(this.getAttribute('flyer-transitionend') || 'flyer-transitionend', this.transitionendListener, { once: true })
     } else if (this.getAttribute('timeout') && this.getAttribute('timeout') !== null) {
       setTimeout(() => {
-        if (this.shouldComponentRenderHTML()) this.render()
+        if (this.shouldRenderHTML()) this.render()
       }, Number(this.getAttribute('timeout')))
-    } else if (this.shouldComponentRenderHTML()) this.render()
+    } else if (this.shouldRenderHTML()) this.render()
   }
 
   disconnectedCallback () {
@@ -64,7 +64,7 @@ export default class CookieBanner extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.scripts.length
   }
 

--- a/src/es/components/msrc/login/Login.js
+++ b/src/es/components/msrc/login/Login.js
@@ -80,7 +80,7 @@ export default class Login extends Prototype() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRender()) showPromises.push(this.render())
+    if (this.shouldRender()) showPromises.push(this.render())
     Promise.all(showPromises).then(() => (this.hidden = false))
     document.body.addEventListener(this.getAttribute('request-msrc-user') || 'request-msrc-user', this.requestMsrcUserListener)
   }
@@ -94,7 +94,7 @@ export default class Login extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRender () {
+  shouldRender () {
     return !this.msrcLoginButtonWrapper
   }
 

--- a/src/es/components/msrc/productList/ProductList.js
+++ b/src/es/components/msrc/productList/ProductList.js
@@ -47,10 +47,10 @@ export default class ProductList extends Intersection(Prototype()) {
     if ((this.isIntersecting = entries && entries[0] && entries[0].isIntersecting)) {
       this.hidden = true
       const showPromises = []
-      if (this.shouldComponentRender()) showPromises.push(this.render())
+      if (this.shouldRender()) showPromises.push(this.render())
       Promise.all(showPromises).then(() => {
         this.hidden = false
-        if (this.shouldComponentRenderCSS()) {
+        if (this.shouldRenderCSS()) {
           this.renderCSS()
           // Issue loading animation hanging
           // https://jira.migros.net/browse/SHAREDCMP-2625
@@ -131,11 +131,11 @@ export default class ProductList extends Intersection(Prototype()) {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
-  shouldComponentRender () {
+  shouldRender () {
     return !this.msrcProductListWrapper
   }
 

--- a/src/es/components/msrc/questionsAnswers/QuestionsAnswers.js
+++ b/src/es/components/msrc/questionsAnswers/QuestionsAnswers.js
@@ -58,7 +58,7 @@ export default class QuestionsAnswers extends Prototype() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRender()) showPromises.push(this.render())
+    if (this.shouldRender()) showPromises.push(this.render())
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -67,7 +67,7 @@ export default class QuestionsAnswers extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRender () {
+  shouldRender () {
     return !this.msrcContainer
   }
 

--- a/src/es/components/msrc/ratingsReviews/RatingsReviews.js
+++ b/src/es/components/msrc/ratingsReviews/RatingsReviews.js
@@ -59,7 +59,7 @@ export default class RatingsReviews extends Prototype() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRender()) showPromises.push(this.render())
+    if (this.shouldRender()) showPromises.push(this.render())
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -68,7 +68,7 @@ export default class RatingsReviews extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRender () {
+  shouldRender () {
     return !this.msrcContainer
   }
 

--- a/src/es/components/msrc/reviewsSummary/ReviewsSummary.js
+++ b/src/es/components/msrc/reviewsSummary/ReviewsSummary.js
@@ -56,7 +56,7 @@ export default class ReviewsSummary extends Prototype() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRender()) showPromises.push(this.render())
+    if (this.shouldRender()) showPromises.push(this.render())
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -65,7 +65,7 @@ export default class ReviewsSummary extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRender () {
+  shouldRender () {
     return !this.msrcContainer
   }
 

--- a/src/es/components/msrc/storeFinder/StoreFinder.js
+++ b/src/es/components/msrc/storeFinder/StoreFinder.js
@@ -83,7 +83,7 @@ export default class StoreFinder extends Prototype() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRender()) showPromises.push(this.render())
+    if (this.shouldRender()) showPromises.push(this.render())
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -92,7 +92,7 @@ export default class StoreFinder extends Prototype() {
    *
    * @return {boolean}
    */
-  shouldComponentRender () {
+  shouldRender () {
     return !this.msrcStoreFinderWrapper
   }
 

--- a/src/es/components/organisms/body/Body.js
+++ b/src/es/components/organisms/body/Body.js
@@ -61,8 +61,8 @@ export default class Body extends Shadow() {
 
   connectedCallback () {
     super.connectedCallback()
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML()
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML()
     document.body.addEventListener(this.getAttribute('click-anchor') || 'click-anchor', this.clickAnchorEventListener)
     if (location.hash) {
       self.addEventListener('load', event => this.clickAnchorEventListener({ detail: { selector: location.hash.replace('_scrolled', '') } }), { once: true })
@@ -82,7 +82,7 @@ export default class Body extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -91,7 +91,7 @@ export default class Body extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.main
   }
 

--- a/src/es/components/organisms/bodyStyle/BodyStyle.js
+++ b/src/es/components/organisms/bodyStyle/BodyStyle.js
@@ -30,7 +30,7 @@ export default class BodyStyle extends Intersection(Body) {
   intersectionCallback (entries, observer) {
     // render css on intersection because this component is often used for backgrounds including css backgrounds with images. those can by default not be loaded lazy nor support sources, thats why we load them on intersection
     if ((this.isIntersecting = entries && entries[0] && entries[0].isIntersecting)) {
-      if (this.intersectionshouldRenderCSS()) {
+      if (this.intersectionShouldRenderCSS()) {
         if (this.hasAttribute('only-render-attribute-to-css')) {
           this.renderAttributesToCSS()
           this.importStyles()
@@ -56,7 +56,7 @@ export default class BodyStyle extends Intersection(Body) {
    *
    * @return {boolean}
    */
-  intersectionshouldRenderCSS () {
+  intersectionShouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 

--- a/src/es/components/organisms/bodyStyle/BodyStyle.js
+++ b/src/es/components/organisms/bodyStyle/BodyStyle.js
@@ -30,7 +30,7 @@ export default class BodyStyle extends Intersection(Body) {
   intersectionCallback (entries, observer) {
     // render css on intersection because this component is often used for backgrounds including css backgrounds with images. those can by default not be loaded lazy nor support sources, thats why we load them on intersection
     if ((this.isIntersecting = entries && entries[0] && entries[0].isIntersecting)) {
-      if (this.intersectionShouldComponentRenderCSS()) {
+      if (this.intersectionshouldRenderCSS()) {
         if (this.hasAttribute('only-render-attribute-to-css')) {
           this.renderAttributesToCSS()
           this.importStyles()
@@ -47,7 +47,7 @@ export default class BodyStyle extends Intersection(Body) {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return false
   }
 
@@ -56,7 +56,7 @@ export default class BodyStyle extends Intersection(Body) {
    *
    * @return {boolean}
    */
-  intersectionShouldComponentRenderCSS () {
+  intersectionshouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -65,7 +65,7 @@ export default class BodyStyle extends Intersection(Body) {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return false
   }
 

--- a/src/es/components/organisms/footer/Footer.js
+++ b/src/es/components/organisms/footer/Footer.js
@@ -38,8 +38,8 @@ export default class Footer extends Shadow() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) showPromises.push(this.renderHTML())
     Promise.all(showPromises).then(() => {
       const wrappers = Array.from(this.root.querySelectorAll('o-wrapper[namespace=footer-default-]'))
       Footer.recalcWrappers(wrappers) // make sure that the wrapper has all the variables just set and recalc
@@ -57,7 +57,7 @@ export default class Footer extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -66,7 +66,7 @@ export default class Footer extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.footer
   }
 

--- a/src/es/components/organisms/grid/Grid.js
+++ b/src/es/components/organisms/grid/Grid.js
@@ -15,8 +15,8 @@ export default class Grid extends Shadow() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) showPromises.push(this.renderHTML())
     Promise.all(showPromises).then(() => (this.hidden = false))
   }
 
@@ -25,7 +25,7 @@ export default class Grid extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -34,7 +34,7 @@ export default class Grid extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.grid
   }
 

--- a/src/es/components/organisms/header/Header.js
+++ b/src/es/components/organisms/header/Header.js
@@ -108,8 +108,8 @@ export default class Header extends Shadow() {
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) showPromises.push(this.renderHTML())
     showPromises.push(new Promise(resolve => this.addEventListener('navigation-load', event => resolve(), { once: true })))
     if (this.aLogo && !this.aLogo.hasAttribute('loaded')) showPromises.push(new Promise(resolve => this.addEventListener('logo-load', event => resolve(), { once: true })))
     Promise.all(showPromises).then(() => {
@@ -144,7 +144,7 @@ export default class Header extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -153,7 +153,7 @@ export default class Header extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.header
   }
 

--- a/src/es/components/organisms/modal/Modal.js
+++ b/src/es/components/organisms/modal/Modal.js
@@ -178,8 +178,8 @@ export default class Modal extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
-    if (this.shouldComponentRenderHTML()) this.renderHTML();
+    if (this.shouldRenderCSS()) this.renderCSS()
+    if (this.shouldRenderHTML()) this.renderHTML();
     (this.getAttribute('listen-at') ? document.querySelector(this.getAttribute('listen-at')) : document.body).addEventListener(this.getAttribute('open-modal') || 'open-modal', this.openModalListener)
     this.addEventListener('click', this.clickListener)
     this.addEventListener('click', this.anyCloseModalListener)
@@ -214,7 +214,7 @@ export default class Modal extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -223,7 +223,7 @@ export default class Modal extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.section
   }
 

--- a/src/es/components/organisms/wrapper/Wrapper.js
+++ b/src/es/components/organisms/wrapper/Wrapper.js
@@ -41,8 +41,8 @@ export const Wrapper = (ChosenHTMLElement = Body) => class Wrapper extends Chose
   connectedCallback () {
     this.hidden = true
     const showPromises = []
-    if (this.shouldComponentRenderHTML()) showPromises.push(this.renderHTML())
-    if (this.shouldComponentRenderCSS()) showPromises.push(this.renderCSS())
+    if (this.shouldRenderHTML()) showPromises.push(this.renderHTML())
+    if (this.shouldRenderCSS()) showPromises.push(this.renderCSS())
     Promise.all(showPromises).then(() => {
       this.hidden = false
     })
@@ -62,7 +62,7 @@ export const Wrapper = (ChosenHTMLElement = Body) => class Wrapper extends Chose
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -71,7 +71,7 @@ export const Wrapper = (ChosenHTMLElement = Body) => class Wrapper extends Chose
    *
    * @return {boolean}
    */
-  shouldComponentRenderHTML () {
+  shouldRenderHTML () {
     return !this.section
   }
 

--- a/src/es/components/pages/general/General.js
+++ b/src/es/components/pages/general/General.js
@@ -32,7 +32,7 @@ export default class General extends Shadow() {
   }
 
   connectedCallback () {
-    if (this.shouldComponentRenderCSS()) this.renderCSS()
+    if (this.shouldRenderCSS()) this.renderCSS()
     this.addEventListener(this.getAttribute('no-scroll') || 'no-scroll', this.noScrollEventListener)
   }
 
@@ -45,7 +45,7 @@ export default class General extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldComponentRenderCSS () {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 


### PR DESCRIPTION
- search and replace
- smoke test of all components

---

refactor(arrow.js, breadcrumb.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML

refactor(Button.js, EMail.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency

refactor(EmotionPictures.js, GoogleMaps.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML

refactor: rename shouldComponentRenderCSS to shouldRenderCSS in Hotspot.js and IconAmp.js
refactor: rename shouldComponentRenderHTML to shouldRenderHTML in Hotspot.js and IconAmp.js

refactor(IconLocation.js, IconPaperclip.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML

refactor(Iframe.js, Input.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor: rename shouldComponentRenderCSS to shouldRenderCSS in Link.js and Loading.js
refactor: rename shouldComponentRenderHTML to shouldRenderHTML in Link.js and Loading.js

refactor(Logo.js, MenuIcon.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor(Picture.js, SliderButton.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor(TotalPrice.js, Video.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor(News.js, NewsList.js): rename shouldComponentRenderCSS to shouldRenderCSS for consistency

refactor(NewsPreview.js, TagManager.js): rename shouldComponentRenderHTML to shouldRenderHTML and shouldComponentRenderCSS to shouldRenderCSS

refactor(Widget.js, Carousel.js): rename shouldComponentRender to shouldRender for consistency and clarity

refactor(carouselTwo.js, cookieBanner.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor(Details.js, Flockler.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor(Form.js, ImageHotspot.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency

refactor(Navigation.js, Pagination.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency and clarity

refactor(PictureText.js, PictureWithPicture.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency

refactor(RecipeList.js, TagFilter.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML

refactor(Teaser.js): rename shouldComponentRenderCSS to shouldRenderCSS and update its usage in the code

refactor(CookieBanner.js, Login.js): rename shouldComponentRenderHTML to shouldRender for consistency and clarity

refactor(ProductList.js, QuestionsAnswers.js): rename shouldComponentRender to shouldRender

refactor(RatingsReviews.js, ReviewsSummary.js, StoreFinder.js): rename shouldComponentRender method to shouldRender

refactor(Body.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML.

refactor(BodyStyle.js): rename shouldComponentRenderCSS to shouldRenderCSS and intersectionShouldComponentRenderCSS to intersectionshouldRenderCSS for consistency and readability

refactor(organisms): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML in Footer.js and Grid.js components

refactor(Header.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML, to improve code readability and consistency

refactor(modal.js, wrapper.js): rename shouldComponentRenderCSS to shouldRenderCSS and shouldComponentRenderHTML to shouldRenderHTML for consistency

refactor(General.js): rename shouldComponentRenderCSS to shouldRenderCSS and update its usage in connectedCallback and shouldRenderCSS method.