### PR TITLE
feat(DateInput.js): add atom component DateInput with links to primary and secondary pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,16 @@
       </ul>
     `
     </script>
+    <h3>DateInput</h3>
+    <div id=date-input></div>
+    <script>
+      document.querySelector('#date-input').innerHTML = /* HTML */`
+      <ul>
+        <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/atoms/dateInput/primary-/primary-.html">"primary-" Page</a> / <a href=./src/es/components/atoms/dateInput/primary-/primary-.html>"primary-" Plain</a></li>
+        <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/atoms/dateInput/secondary-/secondary-.html">"secondary-" Page</a> / <a href=./src/es/components/atoms/dateInput/secondary-/secondary-.html>"secondary-" Plain</a></li>
+      </ul>
+    `
+    </script>
     <h3>Picture</h3>
     <div id=picture></div>
     <script>

--- a/src/es/components/atoms/basket/Basket.js
+++ b/src/es/components/atoms/basket/Basket.js
@@ -7,33 +7,32 @@ import { Shadow } from '../../prototypes/Shadow.js'
  * @type {CustomElementConstructor}
  */
 export default class Basket extends Shadow() {
-
-  constructor(...args) {
+  constructor (...args) {
     super(...args)
-    
+
     this.answerEventNameListener = event => {
-      
       // WIP!!!
-      console.log("event", event.detail)
+      console.log('event', event.detail)
       this.count.innerHTML = Number(this.count.innerHTML) + 1
     }
   }
 
-
-  connectedCallback() {
+  connectedCallback () {
     if (this.shouldRenderCSS()) this.renderCSS()
     if (this.shouldRenderHTML()) this.renderHTML()
     document.body.addEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
   }
-  disconnectedCallback() {
+
+  disconnectedCallback () {
     document.body.removeEventListener(this.getAttribute('answer-event-name') || 'answer-event-name', this.answerEventNameListener)
   }
+
   /**
    * evaluates if a render is necessary
    *
    * @return {boolean}
    */
-  shouldRenderCSS() {
+  shouldRenderCSS () {
     return !this.root.querySelector(`:host > style[_css], ${this.tagName} > style[_css]`)
   }
 
@@ -42,7 +41,7 @@ export default class Basket extends Shadow() {
    *
    * @return {boolean}
    */
-  shouldRenderHTML() {
+  shouldRenderHTML () {
     return !this.img
   }
 
@@ -51,7 +50,7 @@ export default class Basket extends Shadow() {
    *
    * @return {Promise<void>}
    */
-  renderCSS() {
+  renderCSS () {
     this.css = /* css */`
       :host {
         display:block;
@@ -86,7 +85,7 @@ export default class Basket extends Shadow() {
    *
    * @return {Promise<void>}
    */
-  fetchTemplate() {
+  fetchTemplate () {
     switch (this.getAttribute('namespace')) {
       case 'basket-default-':
         return this.fetchCSS([{
@@ -103,9 +102,9 @@ export default class Basket extends Shadow() {
    *
    * @return {void}
    */
-  renderHTML() {
-    this.wrapper = this.root.querySelector('div') || document.createElement('div');
-    this.count = this.root.querySelector('span') || document.createElement('span');
+  renderHTML () {
+    this.wrapper = this.root.querySelector('div') || document.createElement('div')
+    this.count = this.root.querySelector('span') || document.createElement('span')
     this.count.innerHTML = '0'
     this.wrapper.appendChild(this.count)
     this.img = this.root.querySelector('img') || document.createElement('img')
@@ -114,7 +113,7 @@ export default class Basket extends Shadow() {
     this.html = this.wrapper
   }
 
-  get icon() {
+  get icon () {
     return this.getAttribute('icon')
   }
 }

--- a/src/es/components/atoms/dateInput/DateInput.js
+++ b/src/es/components/atoms/dateInput/DateInput.js
@@ -168,8 +168,10 @@ export default class DateInput extends Shadow() {
             touch-action: manipulation;
             transition: var(--transition, background-color 0.3s ease-out, border-color 0.3s ease-out, color 0.3s ease-out);
             width: var(--width, auto);
+            min-width: var(--min-width, 240px);
         }
         :host .date-input:hover, :host(.hover) .date-input {
+            cursor: pointer;
             background-color: var(--background-color-hover, var(--background-color, #B24800));
             border: var(--border-width-hover, var(--border-width, 0px)) solid var(--border-color-hover, var(--border-color, #FFFFFF));
             color: var(--color-hover, var(--color, #FFFFFF));
@@ -198,9 +200,7 @@ export default class DateInput extends Shadow() {
             opacity: var(--opacity-disabled, var(--opacity, 0.5));
         }
         :host .date-input::-webkit-calendar-picker-indicator {
-            color: transparent;
-            background: none;
-            z-index: 1;
+            display: none;
         }
         @media only screen and (max-width: _max-width_) {
             :host .date-input {
@@ -260,7 +260,7 @@ export default class DateInput extends Shadow() {
     dateInput.name = dateInput.id
     dateInput.type = 'text'
 
-    dateInput.onfocus = () => {
+    const showDatePicker = () => {
       if (dateInput.value) {
         const dateValue = dateInput.value.replace(calendarIndicator, '')
         const parts = dateValue.split('.')
@@ -274,9 +274,41 @@ export default class DateInput extends Shadow() {
       dateInput.showPicker()
     }
 
+    // dateInput.onclick = () => {
+    //   showDatePicker();
+    // }
+
+    // dateInput.onmouseenter = () => {
+    //   showDatePicker();
+    // }
+
+    // dateInput.onmousedown = () => {
+    //   showDatePicker();
+    // }
+
+    // dateInput.ontouchstart = () => {
+    //   showDatePicker();
+    // }
+
+    dateInput.onfocus = () => {
+      showDatePicker();
+    }
+
     dateInput.onblur = () => {
       dateInput.type = 'text'
     }
+
+    // dateInput.onmouseleave = () => {
+    //   dateInput.type = 'text'
+    // }
+
+    // dateInput.onmouseout = () => {
+    //   dateInput.type = 'text'
+    // }
+
+    // dateInput.ontouchend = () => {
+    //   dateInput.type = 'text'
+    // }
 
     dateInput.onchange = () => {
       if (dateInput.value) {

--- a/src/es/components/atoms/dateInput/DateInput.js
+++ b/src/es/components/atoms/dateInput/DateInput.js
@@ -1,0 +1,313 @@
+// @ts-check
+import { Shadow } from '../../prototypes/Shadow.js'
+
+/**
+ * DateInput
+ * An example at: default-/default-.html
+ *
+ * @export
+ * @class DateInput
+ * @type {CustomElementConstructor}
+ */
+
+export default class DateInput extends Shadow() {
+  static get observedAttributes () {
+    return ['label', 'disabled']
+  }
+
+  constructor (options = {}, ...args) {
+    super(
+      { hoverInit: undefined, importMetaUrl: import.meta.url, ...options },
+      ...args
+    )
+
+    this.clickListener = (event) => {
+      if (this.hasAttribute('disabled')) event.preventDefault()
+      if (this.getAttribute('request-event-name')) {
+        event.preventDefault()
+        this.dateInput.classList.toggle('active')
+        this.dateInput.setAttribute(
+          'aria-pressed',
+          this.dateInput.classList.contains('active')
+        )
+        this.dispatchEvent(
+          new CustomEvent(this.getAttribute('request-event-name'), {
+            detail: this.getEventDetail(event),
+            bubbles: true,
+            cancelable: true,
+            composed: true
+          })
+        )
+      }
+    }
+
+    this.answerEventListener = async (event) => {
+      let tags = event.detail.tags
+      if (this.getAttribute('active-detail-property-name')) {
+        tags = await this.getAttribute('active-detail-property-name')
+          .split(':')
+          .reduce(async (accumulator, propertyName) => {
+            // @ts-ignore
+            propertyName = propertyName.replace(/-([a-z]{1})/g, (match, p1) =>
+              p1.toUpperCase()
+            )
+            if (accumulator instanceof Promise) accumulator = await accumulator
+            return accumulator[propertyName]
+          }, event.detail)
+      }
+      if (tags) {
+        const tagsIncludesTag = this.hasAttribute('tag-search')
+          ? tags.some((tag) => tag.includes(this.getAttribute('tag-search')))
+          : tags.includes(this.getAttribute('tag'))
+        this.dateInput.classList[tagsIncludesTag ? 'add' : 'remove']('active')
+      }
+      this.dateInput.setAttribute(
+        'aria-pressed',
+        this.dateInput.classList.contains('active')
+      )
+    }
+  }
+
+  connectedCallback () {
+    super.connectedCallback()
+    if (this.shouldRenderCSS()) {
+      this.renderCSS()
+    }
+    if (this.shouldRenderHTML()) {
+      this.renderHTML()
+    }
+    this.dateInput.addEventListener('click', this.clickListener)
+    if (this.getAttribute('answer-event-name')) {
+      document.body.addEventListener(
+        this.getAttribute('answer-event-name'),
+        this.answerEventListener
+      )
+    }
+    this.attributeChangedCallback()
+    this.connectedCallbackOnce()
+  }
+
+  connectedCallbackOnce () {
+    if (document.body.hasAttribute('wc-config-load')) {
+      this.wcConfigLoadListener()
+    } else {
+      document.body.addEventListener(
+        this.getAttribute('wc-config-load') || 'wc-config-load',
+        this.wcConfigLoadListener,
+        { once: true }
+      )
+    }
+    this.connectedCallbackOnce = () => {}
+  }
+
+  disconnectedCallback () {
+    this.dateInput.removeEventListener('click', this.clickListener)
+    if (this.getAttribute('answer-event-name')) {
+      document.body.removeEventListener(
+        this.getAttribute('answer-event-name'),
+        this.answerEventListener
+      )
+    }
+  }
+
+  // @ts-ignore
+  attributeChangedCallback () {
+    this.hasAttribute('disabled')
+        ? this.dateInput.setAttribute('disabled', '')
+        : this.dateInput.removeAttribute('disabled')
+    this.hasAttribute('aria-disabled')
+        ? this.dateInput.setAttribute('aria-disabled', 'true')
+        : this.dateInput.removeAttribute('aria-disabled')
+  }
+
+  /**
+   * evaluates if a render is necessary
+   *
+   * @return {boolean}
+   */
+  shouldRenderCSS () {
+    return !this.root.querySelector('style[_css]')
+  }
+
+  /**
+   * evaluates if a render is necessary
+   *
+   * @return {boolean}
+   */
+  shouldRenderHTML () {
+    return !this.dateInput
+  }
+
+  renderCSS () {
+    this.css = /* css */ `
+        :host {
+            cursor: unset !important;
+            display: inline-block;
+        }
+        :host .date-input {
+            align-items: center;
+            background-color: var(--background-color, transparent);
+            border-radius: var(--border-radius, 0.5em);
+            border: var(--border-width, 0px) solid var(--border-color, transparent);
+            color: var(--color, black);
+            cursor: pointer;
+            display: flex;
+            font-family: var(--font-family, unset);
+            font-size: var(--font-size, 1em);
+            font-weight: var(--font-weight, 400);
+            justify-content: var(--justify-content, center);
+            letter-spacing: var(--letter-spacing, normal);
+            line-height: var(--line-height, 1.5em);
+            margin: var(--margin, auto);
+            opacity: var(--opacity, 1);
+            outline: var(--outline, none);
+            overflow: hidden;
+            padding: var(--padding, calc(0.75em - var(--border-width, 0px)) calc(1.5em - var(--border-width, 0px)));
+            text-decoration: var(--text-decoration, none);
+            text-transform: var(--text-transform, none);
+            touch-action: manipulation;
+            transition: var(--transition, background-color 0.3s ease-out, border-color 0.3s ease-out, color 0.3s ease-out);
+            width: var(--width, auto);
+        }
+        :host .date-input:hover, :host(.hover) .date-input {
+            background-color: var(--background-color-hover, var(--background-color, #B24800));
+            border: var(--border-width-hover, var(--border-width, 0px)) solid var(--border-color-hover, var(--border-color, #FFFFFF));
+            color: var(--color-hover, var(--color, #FFFFFF));
+            opacity: var(--opacity-hover, var(--opacity, 1));
+        }
+        :host .date-input:active, :host .date-input.active {
+            background-color: var(--background-color-active, var(--background-color-hover, var(--background-color, #803300)));
+            color: var(--color-active, var(--color-hover, var(--color, #FFFFFF)));
+        }
+        :host .date-input[disabled] {
+            border: var(--border-width-disabled, var(--border-width, 0px)) solid var(--border-color-disabled, var(--border-color, #FFFFFF));
+            background-color: var(--background-color-disabled, var(--background-color, #FFDAC2));
+            color: var(--color-disabled, var(--color, #FFFFFF));
+            cursor: not-allowed;
+            opacity: var(--opacity-disabled, var(--opacity, 1));
+            transition: opacity 0.3s ease-out;
+        }
+        :host .date-input[disabled]:hover, :host(.hover) .date-input[disabled]  {
+            opacity: var(--opacity-disabled-hover, var(--opacity-disabled, var(--opacity, 1)));
+        }
+        :host .date-input::placeholder {
+            color: var(--color, black);
+        }
+        :host .date-input[disabled]::placeholder {
+            color: var(--color-disabled, var(--color, #FFFFFF));
+            opacity: var(--opacity-disabled, var(--opacity, 0.5));
+        }
+        :host .date-input::-webkit-calendar-picker-indicator {
+            color: transparent;
+            background: none;
+            z-index: 1;
+        }
+        @media only screen and (max-width: _max-width_) {
+            :host .date-input {
+                font-size: var(--font-size-mobile, var(--font-size, 1em));
+                margin: var(--margin-mobile, var(--margin, auto));
+                border-radius: var(--border-radius-mobile, var(--border-radius, 0.571em));
+            }
+            :host .date-input:hover, :host(.hover) .date-input {
+                background-color: var(--background-color-hover-mobile, var(--background-color-hover, var(--background-color, #B24800)));
+                color: var(--color-hover-mobile, var(--color-hover, var(--color, #FFFFFF)));
+            }
+            :host .date-input:active, :host .date-input.active {
+                background-color: var(--background-color-active-mobile, var(--background-color-active, var(--background-color-hover, var(--background-color, #803300))));
+                color: var(--color-active-mobile, var(--color-active, var(--color-hover, var(--color, #FFFFFF))));
+            }
+        }
+    `
+    return this.fetchTemplate()
+  }
+
+  /**
+   * fetches the template
+   *
+   * @return {Promise<void>}
+   */
+  fetchTemplate () {
+    switch (this.getAttribute('namespace')) {
+      case 'date-input-primary-':
+        return this.fetchCSS([
+          {
+            // @ts-ignore
+            path: `${this.importMetaUrl}./primary-/primary-.css`,
+            namespace: false
+          }
+        ])
+      case 'date-input-secondary-':
+        return this.fetchCSS([
+          {
+            // @ts-ignore
+            path: `${this.importMetaUrl}./secondary-/secondary-.css`,
+            namespace: false
+          }
+        ])
+      default:
+        return Promise.resolve()
+    }
+  }
+
+  renderHTML () {
+    const dateInput = document.createElement('input')
+    const calendarIndicator = this.hasAttribute('calendarIndicator')
+      ? this.getAttribute('calendarIndicator')
+      : ''
+
+    dateInput.id = 'date-picker'
+    dateInput.className = 'date-input'
+    dateInput.name = dateInput.id
+    dateInput.type = 'text'
+
+    dateInput.onfocus = () => {
+      if (dateInput.value) {
+        const dateValue = dateInput.value.replace(calendarIndicator, '')
+        const parts = dateValue.split('.')
+        const formattedDate = `${parts[2]}-${parts[1].padStart(
+          2,
+          '0'
+        )}-${parts[0].padStart(2, '0')}`
+        dateInput.value = formattedDate
+      }
+      dateInput.type = 'date'
+      dateInput.showPicker()
+    }
+
+    dateInput.onblur = () => {
+      dateInput.type = 'text'
+    }
+
+    dateInput.onchange = () => {
+      if (dateInput.value) {
+        const formattedDate = new Date(dateInput.value).toLocaleDateString('de-CH')
+        dateInput.blur()
+        dateInput.value = formattedDate + calendarIndicator
+      }
+      if (!dateInput.value) {
+        dateInput.blur()
+      }
+    }
+
+    if (this.hasAttribute('min')) {
+      dateInput.setAttribute('min', this.getAttribute('min'))
+    }
+
+    if (this.hasAttribute('max')) {
+      dateInput.setAttribute('max', this.getAttribute('max'))
+    }
+
+    if (this.hasAttribute('placeholder')) {
+      dateInput.setAttribute(
+        'placeholder',
+        this.getAttribute('placeholder') + calendarIndicator
+      )
+    }
+
+    if (this.hasAttribute('disabled')) {
+        dateInput.setAttribute('disabled', this.getAttribute('disabled'))
+    }
+
+    this.html = dateInput
+  }
+}

--- a/src/es/components/atoms/dateInput/primary-/primary-.css
+++ b/src/es/components/atoms/dateInput/primary-/primary-.css
@@ -1,0 +1,7 @@
+:host {
+    --date-input-primary-background-color-disabled: var(--button-primary-background-color-disabled-custom, var(--color-disabled, var(--m-orange-300)));
+    --date-input-primary-background-color-hover: var(--button-primary-background-color-hover-custom, var(--color-hover, var(--m-orange-800)));
+    --date-input-primary-background-color: var(--button-primary-background-color-custom, var(--color-secondary, var(--m-orange-600)));
+    --date-input-primary-color: var(--button-primary-color-custom, var(--background-color, var(--m-white)));
+    --date-input-primary-font-family: var(--font-family);
+}

--- a/src/es/components/atoms/dateInput/primary-/primary-.html
+++ b/src/es/components/atoms/dateInput/primary-/primary-.html
@@ -1,0 +1,21 @@
+<a-date-input 
+    namespace="date-input-primary-"
+    placeholder="Datum auswählen"
+    calendarIndicator=" → 📅"
+    min="2024-08-20" 
+    max="2024-09-12" 
+></a-date-input>
+
+<a-date-input 
+    namespace="date-input-primary-"
+    placeholder="Datum auswählen"
+    calendarIndicator=" → 📅"
+    min="2024-08-20" 
+    max="2024-09-12" 
+    disabled
+></a-date-input>
+
+<!-- load web components for Demo Purposes Only -->
+<script class=template-script type="text/javascript" src="./primary-.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/loader.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/documenter.js?component=DateInput.js"></script>

--- a/src/es/components/atoms/dateInput/primary-/primary-.html
+++ b/src/es/components/atoms/dateInput/primary-/primary-.html
@@ -15,6 +15,10 @@
     disabled
 ></a-date-input>
 
+<input type="date" />
+
+<input id="date-picker" class="date-input" name="date-picker" type="date" min="2024-08-20" max="2024-09-12" placeholder="Datum auswählen → 📅">
+
 <!-- load web components for Demo Purposes Only -->
 <script class=template-script type="text/javascript" src="./primary-.js"></script>
 <script type="text/javascript" src="../../../../../../docs/es/loader.js"></script>

--- a/src/es/components/atoms/dateInput/primary-/primary-.js
+++ b/src/es/components/atoms/dateInput/primary-/primary-.js
@@ -1,0 +1,3 @@
+// For Demo Purposes Only
+document.body.setAttribute('style', '--background-color: #eee;')
+if (document.querySelector(':root')) document.querySelector(':root').setAttribute('style', '--background-color: #eee;')

--- a/src/es/components/atoms/dateInput/secondary-/secondary-.css
+++ b/src/es/components/atoms/dateInput/secondary-/secondary-.css
@@ -1,0 +1,13 @@
+:host {
+    --date-input-secondary-background-color-disabled: transparent;
+    --date-input-secondary-background-color-hover: transparent;
+    --date-input-secondary-background-color: transparent;
+    --date-input-secondary-border-color-disabled: var(--button-secondary-border-color-disabled-custom, var(--color-disabled, var(--m-orange-300)));
+    --date-input-secondary-border-color-hover: var(--button-secondary-border-color-hover-custom, var(--color-hover, var(--m-orange-800)));
+    --date-input-secondary-border-color: var(--button-secondary-border-color-custom, var(--color-secondary, var(--m-orange-600)));
+    --date-input-secondary-border-width: 2px;
+    --date-input-secondary-color-disabled: var(--button-secondary-color-disabled-custom, var(--color-disabled, var(--m-orange-300)));
+    --date-input-secondary-color-hover: var(--button-secondary-color-hover-custom, var(--color-hover, var(--m-orange-800)));
+    --date-input-secondary-color: var(--button-secondary-color-custom, var(--color-secondary, var(--m-orange-600)));
+    --date-input-secondary-font-family: var(--font-family);
+}

--- a/src/es/components/atoms/dateInput/secondary-/secondary-.html
+++ b/src/es/components/atoms/dateInput/secondary-/secondary-.html
@@ -1,0 +1,21 @@
+<a-date-input 
+    namespace="date-input-secondary-"
+    placeholder="Datum auswählen"
+    calendarIndicator=" → 📅"
+    min="2024-08-20" 
+    max="2024-09-12" 
+></a-date-input>
+
+<a-date-input 
+    namespace="date-input-secondary-"
+    placeholder="Datum auswählen"
+    calendarIndicator=" → 📅"
+    min="2024-08-20" 
+    max="2024-09-12" 
+    disabled
+></a-date-input>
+
+<!-- load web components for Demo Purposes Only -->
+<script class=template-script type="text/javascript" src="./secondary-.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/loader.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/documenter.js?component=DateInput.js"></script>

--- a/src/es/components/atoms/dateInput/secondary-/secondary-.js
+++ b/src/es/components/atoms/dateInput/secondary-/secondary-.js
@@ -1,0 +1,3 @@
+// For Demo Purposes Only
+document.body.setAttribute('style', '--background-color: #eee;')
+if (document.querySelector(':root')) document.querySelector(':root').setAttribute('style', '--background-color: #eee;')


### PR DESCRIPTION
# DateInput.js

A new atom component! 👏🏻 

![Screenshot 2023-07-05 at 15 05 29](https://github.com/mits-gossau/web-components-toolbox/assets/1226135/e9d6ba22-4213-480c-aee6-74c5dcac9161)

![Screenshot 2023-07-05 at 15 05 37](https://github.com/mits-gossau/web-components-toolbox/assets/1226135/bcdf8705-e791-4ddd-afef-85ba25689adc)

<img src="https://github.com/mits-gossau/web-components-toolbox/assets/1226135/462024d9-c57f-4f18-8087-e9299bf8af87" width="480" />

---

refactor(Basket.js): fix indentations and remove unnecessary comments

feat(dateInput.js): add DateInput component
feat(dateInput): add primary date input component
feat(dateInput): add secondary date input component
