### PR TITLE
feat(button): add support for "action-" button type

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
         <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/atoms/button/category-/category-.html">"category-" Page</a> / <a href=./src/es/components/atoms/button/category-/category-.html>"category-" Plain</a></li>
         <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/atoms/button/category-teaser-/category-teaser-.html">"category-teaser-" Page</a> / <a href=./src/es/components/atoms/button/category-teaser-/category-teaser-.html>"category-teaser-" Plain</a></li>
         <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/atoms/button/square-/square-.html">"square-" Page</a> / <a href=./src/es/components/atoms/button/square-/square-.html>"square-" Plain</a></li>
+        <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/atoms/button/action-/action-.html">"action-" Page</a> / <a href=./src/es/components/atoms/button/action-/action-.html>"action-" Plain</a></li>
       </ul>
     `
     </script>

--- a/src/es/components/atoms/button/Button.js
+++ b/src/es/components/atoms/button/Button.js
@@ -382,6 +382,13 @@ export default class Button extends Hover() {
           namespace: false,
           replaces
         }])
+      case 'button-action-':
+        return this.fetchCSS([{
+          // @ts-ignore
+          path: `${this.importMetaUrl}./action-/action-.css`,
+          namespace: false,
+          replaces
+        }])
       default:
         return Promise.resolve()
     }

--- a/src/es/components/atoms/button/action-/action-.css
+++ b/src/es/components/atoms/button/action-/action-.css
@@ -1,0 +1,5 @@
+:host {
+  --button-action-color: var(--button-action-color-custom, var(--color-secondary));
+  --button-action-color-hover: var(--button-action-color-hover-custom, var(--m-white));
+  --button-action-padding: var(--button-action-padding-custom, 0.5rem 1rem);
+}

--- a/src/es/components/atoms/button/action-/action-.html
+++ b/src/es/components/atoms/button/action-/action-.html
@@ -1,0 +1,40 @@
+<a-button namespace="button-action-" href="./hello.html" target="_blank">Label</a-button>
+<a-button namespace="button-action-">Label</a-button>
+<a-button namespace="button-action-" label="Label" disabled href="./hello.html" target="_blank"></a-button>
+<a-button namespace="button-action-" label="Label" disabled></a-button>
+<a-button namespace="button-action-">
+  icon-left
+  <svg class="icon-left" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3 18V18C1.89543 18 1 17.1046 1 16V11H21C22.1046 11 23 11.8954 23 13V16C23 17.1046 22.1046 18 21 18H20M8 18H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M1 11L4.40541 4H14.1351L20 11" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M5.5 21C6.88071 21 8 19.8807 8 18.5C8 17.1193 6.88071 16 5.5 16C4.11929 16 3 17.1193 3 18.5C3 19.8807 4.11929 21 5.5 21Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M17.5 21C18.8807 21 20 19.8807 20 18.5C20 17.1193 18.8807 16 17.5 16C16.1193 16 15 17.1193 15 18.5C15 19.8807 16.1193 21 17.5 21Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M11 11L11 4" stroke="currentColor" stroke-width="2"/>
+    </svg>
+</a-button>
+<a-button namespace="button-action-" label="icon-right">
+  <img class="icon-right" src="../../../../../../src/icons/car.svg">
+</a-button>
+<a-button namespace="button-action-" label="icon-left-right">
+  <img class="icon-left" src="../../../../../../src/icons/car.svg">
+  <img class="icon-right" src="../../../../../../src/icons/car.svg">
+</a-button>
+<h2>button with html-nodes/wc-nodes as content</h2>
+<a-button namespace="button-action-" label="icon-mdx">
+  <a-icon-mdx icon-name="ShoppingBasket" size="1em" rotate="0" class="icon-left" namespace="button-action-"></a-icon-mdx>
+</a-button>
+<a-button namespace="button-action-">
+  <m-teaser namespace=teaser-plain->
+    <figure>
+      <a-picture namespace="picture-teaser-" picture-load defaultSource="./img/stadler.jpg" alt="randomized image"></a-picture>
+      <figcaption>
+        <h5>Personalrestaurant Stadler Bussnang</h5>
+        <p>Ernst-Stadler-Strasse 1<br>9565 Bussnang<br>Schweiz</p>
+      </figcaption>
+    </figure>
+  </m-teaser>
+</a-button>
+<!-- load web components for Demo Purposes Only -->
+<script class=template-script type="text/javascript" src="./action-.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/loader.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/documenter.js?component=Button.js"></script>

--- a/src/es/components/atoms/button/action-/action.js
+++ b/src/es/components/atoms/button/action-/action.js
@@ -1,0 +1,3 @@
+// For Demo Purposes Only
+document.body.setAttribute('style', '--background-color: #eee;')
+if (document.querySelector(':root')) document.querySelector(':root').setAttribute('style', '--background-color: #eee;')


### PR DESCRIPTION
feat(button): add "action-" button CSS styles
feat(button): add action button component in ES language
This commit adds the action button component in ES language. The component includes various variations of the button, such as with a label, disabled, with icons, and with HTML nodes as content. It also includes a demo section with web components for demo purposes.
The component is implemented in the `src/es/components/atoms/button/action-/action-.html` file.
feat(button): add action button component with demo styling