### PR TITLE
feat(GoogleTagManager.js): add GoogleTagManager component

### DIFF
--- a/docs/TemplateMigrosPro.html
+++ b/docs/TemplateMigrosPro.html
@@ -17,6 +17,7 @@
     <!-- wc-config.js gets loaded once the template fetched its body path -->
     <!--<script async rel=preload as="script" type="text/javascript" src="../wc-config.js"></script>-->
     <title>Web Components Toolbox 😎</title>
+    <!-- <c-google-tag-manager gtm-id="GTM-PNK6BD2V"></c-google-tag-manager> -->
   </head>
 
   <body>

--- a/src/es/components/controllers/googleTagManager/GoogleTagManager.js
+++ b/src/es/components/controllers/googleTagManager/GoogleTagManager.js
@@ -1,0 +1,54 @@
+// @ts-check
+import { Shadow } from '../../prototypes/Shadow.js'
+
+/**
+ * GoogleTagManager
+ * An example at: src/es/components/pages/TrackingTest.html
+ *
+ * @export
+ * @class GoogleTagManager
+ * @type {CustomElementConstructor}
+ * @attribute {
+ *  {string} gtm-id
+ *  {head|body} [position=head] position of the web component
+ * }
+ * @examples {
+ *   <head>
+ *    ...
+ *     <c-google-tag-manager gtm-id="GTM-PNK6BD2V"></c-google-tag-manager>
+ *   </head>
+ *   <body>
+ *     <c-google-tag-manager gtm-id="GTM-PNK6BD2V" position="body"></c-google-tag-manager>
+ *     ...
+ *   </body>
+ * }
+ */
+
+export default class GoogleTagManager extends Shadow() {
+  connectedCallback() {
+    const gtmId = this.getAttribute("gtm-id") || "GTM-XXXXXX";
+    const position = this.getAttribute("position") || "head"; // default to 'head' if no attribute is provided
+
+    // Construct the GTM script
+    const script = document.createElement("script");
+    script.textContent = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${gtmId}');`;
+
+    // Append the GTM script to the desired position
+    if (position === "head") {
+      document.head.appendChild(script);
+    } else if (position === "body") {
+      document.body.appendChild(script);
+    }
+
+    // Add the noscript part to the body
+    const noscript = document.createElement("noscript");
+    const iframe = document.createElement("iframe");
+    iframe.src = `https://www.googletagmanager.com/ns.html?id=${gtmId}`;
+    iframe.height = "0";
+    iframe.width = "0";
+    iframe.style.display = "none";
+    iframe.style.visibility = "hidden";
+    noscript.appendChild(iframe);
+    this.appendChild(noscript);
+  }
+}

--- a/src/es/components/controllers/googleTagManager/GoogleTagManager.js
+++ b/src/es/components/controllers/googleTagManager/GoogleTagManager.js
@@ -3,7 +3,7 @@ import { Shadow } from '../../prototypes/Shadow.js'
 
 /**
  * GoogleTagManager
- * An example at: src/es/components/pages/TrackingTest.html
+ * An example at: docs/TemplateMigrosPro.html
  *
  * @export
  * @class GoogleTagManager


### PR DESCRIPTION
chore(TemplateMigrosPro.html): comment out c-google-tag-manager component

This commit adds the GoogleTagManager component, which is used to integrate Google Tag Manager into the application. The component accepts two attributes: "gtm-id" and "position". The "gtm-id" attribute specifies the Google Tag Manager ID, and the "position" attribute specifies the position of the component in the HTML document (either "head" or "body").

The connectedCallback method of the component constructs the GTM script based on the provided attributes and appends it to the desired position in the document. Additionally, it adds a noscript part to the body, which includes an iframe for browsers with JavaScript disabled.

Example usage of the component is provided in the commit message.