### PR TITLE
feat(index.html): add link to "left-slide-in-without-background-" page and plain

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,6 +389,7 @@
         <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/molecules/dialog/default-/default-.html">"default-" Page</a> / <a href=./src/es/components/molecules/dialog/default-/default-.html>"default-" Plain</a></li>
         <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/molecules/dialog/top-slide-in-/top-slide-in-.html">"top-slide-in-" Page</a> / <a href=./src/es/components/molecules/dialog/top-slide-in-/top-slide-in-.html>"top-slide-in-" Plain</a></li>
         <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/molecules/dialog/left-slide-in-/left-slide-in-.html">"left-slide-in-" Page</a> / <a href=./src/es/components/molecules/dialog/left-slide-in-/left-slide-in-.html>"left-slide-in-" Plain</a></li>
+        <li><a href="./docs/Template.html?${headerFooterQuery}&content=./src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.html">"left-slide-in-without-background-" Page</a> / <a href=./src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.html>"left-slide-in-without-background-" Plain</a></li>
       </ul>
     `
     </script>   

--- a/src/es/components/molecules/dialog/Dialog.js
+++ b/src/es/components/molecules/dialog/Dialog.js
@@ -117,6 +117,11 @@ export default class Dialog extends Shadow() {
           path: `${this.importMetaUrl}./left-slide-in-/left-slide-in-.css`, // apply namespace since it is specific and no fallback
           namespace: false
         }, ...styles])
+      case 'dialog-left-slide-in-without-background-':
+        return this.fetchCSS([{
+          path: `${this.importMetaUrl}./left-slide-in-without-background-/left-slide-in-without-background-.css`, // apply namespace since it is specific and no fallback
+          namespace: false
+        }, ...styles])
       default:
         return this.fetchCSS(styles)
     }

--- a/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.css
+++ b/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.css
@@ -1,0 +1,161 @@
+:host>dialog[open] {
+  /* open */
+  opacity: 1;
+  transform: translateX(0);
+}
+
+:host>dialog {
+  /* close */
+  border: 0 none;
+  margin: 0;
+  opacity: 1;
+  position: fixed;
+  transform: translateX(-100%);
+  transition: 0.3s;
+  padding: 0;
+  height: 100%;
+  max-height: 100%;
+  width: 100%;
+  max-width: 560px;
+  z-index: 99;
+  display: flex;
+  flex-direction: column;
+}
+
+:host>dialog.closed {
+  /* close */
+  opacity: 0;
+  transform: translateX(-100%);
+}
+
+@starting-style {
+
+  /* before */
+  :host>dialog[open] {
+    opacity: 1;
+    transform: translateX(-100%);
+  }
+}
+
+:host>dialog::backdrop {
+  background-color: transparent;
+  transition: display 0.3s allow-discrete, overlay 0.3s allow-discrete,
+    background-color 0.3s;
+}
+
+:host>dialog[open]::backdrop {
+  background-color: transparent;
+}
+
+@starting-style {
+  :host>dialog[open]::backdrop {
+    background-color: transparent;
+  }
+}
+
+@media only screen and (max-width: _max-width_) {
+  :host .container #close {
+    position: relative;
+    right: 0;
+  }
+}
+
+.container {
+  align-items: center;
+  display: flex;
+  gap: 1.25rem;
+  max-width: _max-width_;
+  width: 100%;
+  margin: 0 auto;
+  padding: calc(24rem/18);
+}
+
+:host .dialog-header {
+  background-color: var(--color-white, #fff);
+  border-bottom: 1px solid var(--color-gray-300, rgba(224, 224, 224, 1));
+  align-items: stretch;
+  display: flex;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+:host .dialog-header>* {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  margin: 0;
+}
+
+:host .dialog-header>h3 {
+  justify-content: center;
+  flex: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:host .dialog-header>#close {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: var(--close-height, 2.25em);
+  justify-content: flex-end;
+  margin-bottom: 0;
+  position: relative;
+  right: 0;
+  width: var(--close-width, var(--close-height, 2.25em));
+}
+
+:host .dialog-header #close a-icon-mdx[icon-name="Plus"]::part(svg) {
+  transform: rotate(45deg);
+}
+
+:host .dialog-content {
+  background-color: var(--color-white, #fff);
+  align-items: start;
+  flex: 1;
+  flex-direction: column;
+  gap: calc(32rem/18);
+  overflow: auto;
+  padding: 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+:host .dialog-content>* {
+  margin: 0;
+  width: 100%;
+}
+
+:host .dialog-footer {
+  background-color: var(--color-white, #fff);
+  border-top: 1px solid var(--color-gray-300, rgba(224, 224, 224, 1));
+  align-items: stretch;
+  display: flex;
+  justify-content: space-between;
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+}
+
+:host .reset-link {
+  text-align: right;
+}
+
+:host .reset-link a {
+  color: var(--mdx-comp-link-color-default);
+  font: var(--mdx-sys-font-fix-label2);
+  text-decoration: none;
+}
+
+:host .reset-link a-icon-mdx {
+  color: var(--mdx-comp-link-color-default);
+  display: inline-block;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  position: relative;
+  top: 0.2rem;
+}

--- a/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.html
+++ b/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.html
@@ -1,0 +1,38 @@
+<m-dialog
+  namespace="dialog-left-slide-in-without-background-"
+>
+  <div class="container dialog-header">
+    <div id="back">
+      <a-icon-mdx icon-name="ChevronLeft" size="2em" ></a-icon-mdx>
+    </div>
+    <h3>Filter</h3>
+    <div id="close">
+      <a-icon-mdx icon-name="Plus" size="2em" ></a-icon-mdx>
+    </div>
+  </div>
+  <div class="container dialog-content">
+    <p class="reset-link"><a>Alles zur&uuml;cksetzen <a-icon-mdx icon-name="RotateLeft" size="1em"></a-icon-mdx></a></p>
+    <div>
+      <p>Content here</p>
+      <p>Content here</p>
+      <p>Content here</p>
+      <p>Content here</p>
+      <p>Content here</p>
+      <p>(scroll down)</p>
+      <p style="height: 500px">...</p>
+      <p>Content here</p>
+      <p>Content here</p>
+      <p>Content here</p>
+    </div>
+  </div>
+  <div class="container dialog-footer">
+    <a-button id="close" namespace="button-secondary-" no-pointer-events>Schliessen</a-button>
+    <a-button namespace="button-primary-">Angebote anzeigen</a-button>
+  </div>
+  
+  <a-button id="show-modal" namespace="button-primary-" no-pointer-events>Show dialog left slide in</a-button>
+</m-dialog>
+<!-- load web components for Demo Purposes Only -->
+<script class=template-script type="text/javascript" src="./left-slide-in-without-background-.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/loader.js"></script>
+<script type="text/javascript" src="../../../../../../docs/es/documenter.js?component=Dialog.js"></script>

--- a/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.js
+++ b/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.js
@@ -1,0 +1,3 @@
+// For Demo Purposes Only
+document.body.setAttribute('style', '--background-color: #eee;')
+if (document.querySelector(':root')) document.querySelector(':root').setAttribute('style', '--background-color: #eee;')


### PR DESCRIPTION
feat(Dialog.js): add support for "dialog-left-slide-in-without-background-" style
feat(dialog.css): add left-slide-in-without-background- dialog CSS styles
feat(dialog): add left slide in dialog without background component

This commit adds a new component for a left slide in dialog without a background. The component is implemented in the HTML file `left-slide-in-without-background-.html` and the JavaScript file `left-slide-in-without-background-.js`. The HTML file contains the structure and content of the dialog, including a header, content, and footer. The JavaScript file sets the background color of the dialog for demo purposes.

Note: The web components used in the HTML file are loaded for demo purposes only.