### PR TITLE
Bugfix: On mobile any-content-with-mobile was not working

### DIFF
--- a/src/es/components/organisms/body/Body.js
+++ b/src/es/components/organisms/body/Body.js
@@ -98,7 +98,7 @@ export default class Body extends Anchor() {
         :host > main {
           padding: var(--main-padding-mobile, var(--main-padding, 0));
         }
-        :host > main > * {
+        :host > main > *:not(m-simple-form-validation) {
           margin: var(--any-content-spacing-mobile, var(--content-spacing-mobile, var(--content-spacing, unset))) auto; /* Warning! Keep horizontal margin at auto, otherwise the content width + margin may overflow into the scroll bar */
           width: var(--any-content-width-mobile, var(--content-width-mobile, calc(100% - var(--content-spacing-mobile, var(--content-spacing)) * 2)));
         }


### PR DESCRIPTION
Reviewed and fixed with @edmgb ,

--any-content-width-mobile was not working. The width was being taken from --any-content-width instead of --any-content-width-mobile.

![image](https://github.com/mits-gossau/web-components-toolbox/assets/84962154/ec035977-4358-4942-826c-bf5ee14ac2b2)
 