### PR TITLE
style(Dialog.js): improve h3 alignment in dialog-header [MIDUWEB-1356]

### DIFF
--- a/src/es/components/molecules/dialog/left-slide-in-/left-slide-in-.css
+++ b/src/es/components/molecules/dialog/left-slide-in-/left-slide-in-.css
@@ -103,6 +103,9 @@
 }
 
 :host .dialog-header > h3 {
+  display: block;
+  margin: auto;
+  text-align: center;
   justify-content: center;
   flex: 3;
   overflow: hidden;

--- a/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.css
+++ b/src/es/components/molecules/dialog/left-slide-in-without-background-/left-slide-in-without-background-.css
@@ -99,6 +99,9 @@
 }
 
 :host .dialog-header > h3 {
+  display: block;
+  margin: auto;
+  text-align: center;
   justify-content: center;
   flex: 3;
   overflow: hidden;


### PR DESCRIPTION
style(left-slide-in-.css): add center alignment to h3 elements in dialog-header
style(left-slide-in-without-background-.css): add center alignment to h3 elements in dialog-header