### PR TITLE
Added sPropagation by clicking on subLi element

### DIFF
--- a/src/es/components/molecules/multiLevelNavigation/MultiLevelNavigation.js
+++ b/src/es/components/molecules/multiLevelNavigation/MultiLevelNavigation.js
@@ -186,6 +186,8 @@ export default class MultiLevelNavigation extends Mutation() {
               subLiElements.forEach(li => {
                 // set aria attributes where needed
                 if (li.hasAttribute('sub-nav')) {
+                  // avoid closing navigation if user clicks on subLi element which has subNavigation
+                  li.addEventListener('click', (event) =>  event.stopPropagation())
                   li.setAttribute('aria-expanded', 'false')
                   li.setAttribute('aria-controls', `${li.getAttribute('sub-nav')}`)
                 }


### PR DESCRIPTION
With the improved navigation using the <template> tag, the event handling on the sub li element has changed slightly. As a result, if a user clicks on an li tag in the navigation that has sub-navigation (which renders on hover), the navigation closes because it listens to the self event listener. We need to stop the li event propagation; therefore, a small change is requested.

The problem is reproducible in the integration environment. If you open the navigation, hover over a sub-navigation item that has a deeper level of sub-navigation, and then click on it, the navigation will close. In the production environment, this issue does not occur since the <template> performance changes have not been implemented yet.

**Important:
This change must go to production alongside the template changes, as they are closely related.**